### PR TITLE
fix: set travis node lts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: node_js
 node_js:
-- node
+- "10.17"
 before_script:
 - npm --silent run sticky:test:sonar -- -Dsonar.organization=bikecoders -Dsonar.host.url=https://sonarcloud.io
   -Dsonar.login=$SONARCLOUD_TOKEN


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the travis ci is failing installing node-sass that [is not supporting node 12](https://github.com/travis-ci/travis-ci/issues/9561#issuecomment-488997608)

Related Issue Number: #18


## What is the new behavior?

The travis CI should work on node Dubnium 10.17.x

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information